### PR TITLE
Add Next.js frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Python
+__pycache__/
+*.py[cod]
+
+# Node
+node_modules/
+.next/
+
+# Misc
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Personal Everything App
 
-This repository contains the initial foundation for a personal "Everything App". The app aims to unify many day–to–day tasks such as note taking, timers and basic integrations with services like YouTube, Gmail and Twitter.
+This repository contains the initial foundation for a personal "Everything App". The app aims to unify many day-to-day tasks such as note taking, timers and basic integrations with services like YouTube, Gmail and Twitter.
 
 ## Features
 
@@ -9,6 +9,7 @@ This repository contains the initial foundation for a personal "Everything App".
 - **Timers module** for simple countdown timers.
 - **Orders module** placeholder for future ordering features.
 - **Integrations** with YouTube, Gmail and Twitter (currently placeholders).
+- **Web UI** built with Next.js located in the `web` directory.
 
 ## Running
 
@@ -20,9 +21,14 @@ python -m everything_app.main
 
 Commands available in the demo:
 
-- `notes` &mdash; add a note.
-- `timer` &mdash; start a timer in seconds.
-- `exit` &mdash; quit the app.
+- `notes` — add a note.
+- `timer` — start a timer in seconds.
+- `exit` — quit the app.
+
+The web frontend can be started locally with:
+
+```bash
+cd web && npm run dev
+```
 
 Feel free to extend the modules and integrations to suit your personal workflow.
-

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "version": 2,
+  "builds": [{ "src": "web/next.config.js", "use": "@vercel/next" }],
+  "routes": [{ "src": "/(.*)", "dest": "web/$1" }]
+}

--- a/web/components/Notes.tsx
+++ b/web/components/Notes.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+
+export default function Notes() {
+  const [notes, setNotes] = useState<string[]>([]);
+  const [text, setText] = useState('');
+
+  useEffect(() => {
+    fetch('http://localhost:8000/notes')
+      .then(res => res.json())
+      .then(setNotes)
+      .catch(() => setNotes([]));
+  }, []);
+
+  const addNote = async () => {
+    await fetch('http://localhost:8000/notes', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text }),
+    });
+    setText('');
+    const res = await fetch('http://localhost:8000/notes');
+    setNotes(await res.json());
+  };
+
+  return (
+    <div>
+      <h2>Notes</h2>
+      <ul>
+        {notes.map((n, i) => (
+          <li key={i}>{n}</li>
+        ))}
+      </ul>
+      <input
+        value={text}
+        onChange={e => setText(e.target.value)}
+        placeholder="Write a note"
+      />
+      <button onClick={addNote}>Add</button>
+    </div>
+  );
+}

--- a/web/components/Timer.tsx
+++ b/web/components/Timer.tsx
@@ -1,0 +1,29 @@
+import { useState } from 'react';
+
+export default function Timer() {
+  const [seconds, setSeconds] = useState(0);
+  const [message, setMessage] = useState('');
+
+  const start = async () => {
+    await fetch('http://localhost:8000/timer', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ seconds }),
+    });
+    setMessage(`Timer for ${seconds} seconds started.`);
+    setSeconds(0);
+  };
+
+  return (
+    <div>
+      <h2>Start Timer</h2>
+      <input
+        type="number"
+        value={seconds}
+        onChange={e => setSeconds(parseInt(e.target.value))}
+      />
+      <button onClick={start}>Go</button>
+      {message && <p>{message}</p>}
+    </div>
+  );
+}

--- a/web/next-env.d.ts
+++ b/web/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "conkers-everything-web",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  }
+}

--- a/web/pages/_app.tsx
+++ b/web/pages/_app.tsx
@@ -1,0 +1,6 @@
+import type { AppProps } from 'next/app';
+import '../styles/globals.css';
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -1,0 +1,13 @@
+import Link from 'next/link';
+
+export default function Home() {
+  return (
+    <main style={{ padding: '2rem' }}>
+      <h1>Conker\'s Everything App</h1>
+      <ul>
+        <li><Link href="/notes">Notes</Link></li>
+        <li><Link href="/timers">Timers</Link></li>
+      </ul>
+    </main>
+  );
+}

--- a/web/pages/notes.tsx
+++ b/web/pages/notes.tsx
@@ -1,0 +1,11 @@
+import Notes from '../components/Notes';
+import Link from 'next/link';
+
+export default function NotesPage() {
+  return (
+    <main style={{ padding: '2rem' }}>
+      <Link href="/">Back</Link>
+      <Notes />
+    </main>
+  );
+}

--- a/web/pages/timers.tsx
+++ b/web/pages/timers.tsx
@@ -1,0 +1,11 @@
+import Timer from '../components/Timer';
+import Link from 'next/link';
+
+export default function TimersPage() {
+  return (
+    <main style={{ padding: '2rem' }}>
+      <Link href="/">Back</Link>
+      <Timer />
+    </main>
+  );
+}

--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -1,0 +1,5 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+}

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add a Next.js project in `web`
- implement notes and timer pages that call the FastAPI backend
- configure Vercel to build and serve the `web` directory
- document new web frontend

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_685203f09434832cba85370aebba9494