### PR TITLE
Add FastAPI server and endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ The project requires Python 3. Run the CLI using:
 python -m everything_app.main
 ```
 
+To run the HTTP API instead, launch:
+
+```bash
+uvicorn everything_app.api:app
+```
+
 Commands available in the demo:
 
 - `notes` &mdash; add a note.

--- a/everything_app/__init__.py
+++ b/everything_app/__init__.py
@@ -34,3 +34,13 @@ class EverythingApp:
         for name in self.integrations:
             print(f" - {name}")
 
+    def run_api(self, host: str = "127.0.0.1", port: int = 8000) -> None:
+        """Start the FastAPI server bound to this ``EverythingApp``."""
+        if not self.modules:
+            self.start()
+        from .api import create_api
+        import uvicorn
+
+        api_app = create_api(self)
+        uvicorn.run(api_app, host=host, port=port)
+

--- a/everything_app/api.py
+++ b/everything_app/api.py
@@ -1,0 +1,38 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+import asyncio
+
+from . import EverythingApp
+
+
+def create_api(app_instance: EverythingApp) -> FastAPI:
+    """Return a FastAPI app wired to an EverythingApp instance."""
+    api = FastAPI()
+
+    class NoteRequest(BaseModel):
+        text: str
+
+    class TimerRequest(BaseModel):
+        seconds: int
+
+    @api.post("/notes")
+    def add_note(note: NoteRequest):
+        """Append a note using the Notes module."""
+        app_instance.modules["notes"].add(note.text)
+        return {"status": "saved"}
+
+    @api.post("/timer")
+    async def start_timer(req: TimerRequest):
+        """Start a timer asynchronously via the Timers module."""
+        asyncio.create_task(
+            asyncio.to_thread(app_instance.modules["timers"].start_timer, req.seconds)
+        )
+        return {"status": "started"}
+
+    return api
+
+
+# Default app used when running ``uvicorn everything_app.api:app``
+_default_app = EverythingApp()
+_default_app.start()
+app = create_api(_default_app)


### PR DESCRIPTION
## Summary
- implement `everything_app.api` FastAPI app with /notes and /timer
- expose `EverythingApp.run_api` to start the server
- document API usage in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685203eba94c832ca3d2aeb593065dce